### PR TITLE
Make initializer and properties of types to be public

### DIFF
--- a/Sources/CGTCalcCore/Models/AssetEvent.swift
+++ b/Sources/CGTCalcCore/Models/AssetEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public class AssetEvent {
-  enum Kind: Equatable {
+  public enum Kind: Equatable {
     /**
      * Capital return.
      * This is also known as "equalisation". It is a part of a dividend that is not regarded as income. It lowers the cost basis for the shares.
@@ -42,7 +42,7 @@ public class AssetEvent {
   let date: Date
   let asset: String
 
-  init(kind: Kind, date: Date, asset: String) {
+  public init(kind: Kind, date: Date, asset: String) {
     self.kind = kind
     self.date = date
     self.asset = asset

--- a/Sources/CGTCalcCore/Models/Transaction.swift
+++ b/Sources/CGTCalcCore/Models/Transaction.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public class Transaction {
-  enum Kind {
+  public enum Kind {
     case Buy
     case Sell
   }
@@ -21,7 +21,7 @@ public class Transaction {
   private(set) var expenses: Decimal
   private(set) var groupedTransactions: [Transaction] = []
 
-  init(kind: Kind, date: Date, asset: String, amount: Decimal, price: Decimal, expenses: Decimal) {
+  public init(kind: Kind, date: Date, asset: String, amount: Decimal, price: Decimal, expenses: Decimal) {
     self.kind = kind
     self.date = date
     self.asset = asset

--- a/Sources/CGTCalcCore/Parser/DefaultParser.swift
+++ b/Sources/CGTCalcCore/Parser/DefaultParser.swift
@@ -18,10 +18,10 @@ enum ParserError: Error {
 }
 
 public class CalculatorInput {
-  let transactions: [Transaction]
-  let assetEvents: [AssetEvent]
+  public let transactions: [Transaction]
+  public let assetEvents: [AssetEvent]
 
-  init(transactions: [Transaction], assetEvents: [AssetEvent]) {
+  public init(transactions: [Transaction], assetEvents: [AssetEvent]) {
     self.transactions = transactions
     self.assetEvents = assetEvents
   }


### PR DESCRIPTION
To use the CGTCalcCore with custom input, these need to be `public`.