### PR TITLE
Modernize the code for grouping transactions by asset name

### DIFF
--- a/Sources/CGTCalcCore/Calculator/Calculator.swift
+++ b/Sources/CGTCalcCore/Calculator/Calculator.swift
@@ -34,18 +34,8 @@ public class Calculator {
   }
 
   private func processTransactions() throws -> CalculatorResult {
-    let transactionsByAsset = self.input.transactions
-      .reduce(into: [String: [Transaction]]()) { result, transaction in
-        var transactions = result[transaction.asset, default: []]
-        transactions.append(transaction)
-        result[transaction.asset] = transactions
-      }
-    let assetEventsByAsset = self.input.assetEvents
-      .reduce(into: [String: [AssetEvent]]()) { result, assetEvent in
-        var assetEvents = result[assetEvent.asset, default: []]
-        assetEvents.append(assetEvent)
-        result[assetEvent.asset] = assetEvents
-      }
+    let transactionsByAsset = Dictionary(grouping: self.input.transactions, by: \.asset)
+    let assetEventsByAsset = Dictionary(grouping: self.input.assetEvents, by: \.asset)
 
     let allAssets = Set<String>(transactionsByAsset.keys).union(Set<String>(assetEventsByAsset.keys))
 


### PR DESCRIPTION
Using "Key Path Expressions" (`\.asset`) to filter, map, etc is supported via [SE-0249](https://github.com/apple/swift-evolution/blob/master/proposals/0249-key-path-literal-function-expressions.md) in Swift 5.2
(This project seems using Swift 5.2, in `Package.swift`)

This change also uses [`Dictionary.init(grouping:by:)`](https://developer.apple.com/documentation/swift/dictionary/3127163-init)