### PR TITLE
Support older tax years.

### DIFF
--- a/Sources/CGTCalcCore/Tax/TaxYear.swift
+++ b/Sources/CGTCalcCore/Tax/TaxYear.swift
@@ -62,6 +62,11 @@ extension TaxYear {
   }
 
   static let rates: [TaxYear: Rates] = [
+    TaxYear(yearEnding: 2009): Rates(exemption: 9600, basicRate: 18, higherRate: 18),
+    TaxYear(yearEnding: 2010): Rates(exemption: 10100, basicRate: 18, higherRate: 18),
+    TaxYear(yearEnding: 2011): Rates(exemption: 10100, basicRate: 18, higherRate: 28),
+    TaxYear(yearEnding: 2012): Rates(exemption: 10600, basicRate: 18, higherRate: 28),
+    TaxYear(yearEnding: 2013): Rates(exemption: 10600, basicRate: 18, higherRate: 28),
     TaxYear(yearEnding: 2014): Rates(exemption: 10900, basicRate: 18, higherRate: 28),
     TaxYear(yearEnding: 2015): Rates(exemption: 11000, basicRate: 18, higherRate: 28),
     TaxYear(yearEnding: 2016): Rates(exemption: 11100, basicRate: 18, higherRate: 28),


### PR DESCRIPTION
Rates based from https://www.rossmartin.co.uk/capital-gains-tax/110-capital-gains-tax-rates-a-allowances