### PR TITLE
Fix quantity match tolerance for Decimal noise from

### DIFF
--- a/Sources/CGTCalcCore/Calculator/CGTEngine.swift
+++ b/Sources/CGTCalcCore/Calculator/CGTEngine.swift
@@ -219,7 +219,9 @@ public enum CGTEngine {
     }
 
     let matchedQuantity = bnbQuantityUsed + section104Matches.reduce(Decimal(0)) { $0 + $1.quantity }
-    guard matchedQuantity == groupedQuantity else {
+    // Tolerance guards against Decimal arithmetic noise from SPLIT/UNSPLIT/RESTRUCT ratio operations.
+    let quantityTolerance = Decimal.parse("0.00000001") ?? Decimal(0)
+    guard abs(matchedQuantity - groupedQuantity) <= quantityTolerance else {
       if let firstLaterAcquisitionDate = self.firstLaterAcquisitionDateForUnsupportedFallback(
         outboundDate: outboundDate,
         buys: assetBuys)

--- a/Tests/CGTCalcCoreTests/CalculatorTests.swift
+++ b/Tests/CGTCalcCoreTests/CalculatorTests.swift
@@ -434,6 +434,46 @@ final class CalculatorTests: XCTestCase {
     XCTAssertEqual(spouseFirstHolding.costBasis, 0, accuracy: 0.00001)
   }
 
+  func testRestructureRoundTripArithmeticProducesDecimalNoise() {
+    // RESTRUCT 3:10 produces a repeating decimal (70/3), exhausting Decimal's 38-digit
+    // precision. The reverse RESTRUCT 10:3 then multiplies the already-truncated value,
+    // so the round-trip result is not exactly equal to the original.
+    let initial = Decimal(7)
+    let afterForwardRestruct = initial * Decimal(10) / Decimal(3)
+    let afterRoundTrip = afterForwardRestruct * Decimal(3) / Decimal(10)
+
+    XCTAssertNotEqual(afterRoundTrip, initial)
+    XCTAssertLessThanOrEqual(abs(afterRoundTrip - initial), Decimal.parse("0.00000001")!)
+  }
+
+  func testDisposalSucceedsAfterRestructureRoundTripDespiteDecimalNoise() throws {
+    // RESTRUCT 3:10 followed by RESTRUCT 10:3 leaves the Section 104 pool at ~6.999...
+    // instead of exactly 7 due to repeating-decimal Decimal noise (see arithmetic test above).
+    // The engine's tolerance comparison must treat this as a full match so the disposal
+    // completes rather than throwing insufficientShares or unsupportedLaterAcquisition.
+    let result = try CGTEngine.calculate(
+      transactions: [
+        TestSupport.buy("01/01/2020", "TEST", 7, 10, 0),
+        TestSupport.sell("01/07/2020", "TEST", 7, 12, 0)
+      ],
+      assetEvents: [
+        AssetEvent(
+          date: TestSupport.date("01/03/2020"),
+          asset: "TEST",
+          oldUnits: 3,
+          newUnits: 10),
+        AssetEvent(
+          date: TestSupport.date("01/05/2020"),
+          asset: "TEST",
+          oldUnits: 10,
+          newUnits: 3)
+      ])
+
+    let summary = try XCTUnwrap(result.taxYearSummaries.first)
+    let disposal = try XCTUnwrap(summary.disposals.first)
+    XCTAssertEqual(disposal.gain, 14, accuracy: 1)
+  }
+
   func testPostBuyDividendIsNotDoubleCountedAcrossThirtyDayAndLaterSection104Disposals() throws {
     let result = try CGTEngine.calculate(transactions: [
       TestSupport.buy("01/01/2020", "TEST", 100, 10, 0),


### PR DESCRIPTION
Problem: When a Section 104 pool has been through a sequence of  RESTRUCT (or SPLIT/UNSPLIT) operations involving non-terminating  ratios (e.g. 3:10 followed by 10:3), repeated Decimal multiplication/division exhausts the 38-digit precision limit. The  matched quantity comes back as 802.999…37 nines… instead of 803, causing the engine to throw unsupportedLaterAcquisitionIdentification even when the user has sufficient shares.

Fix: Replace the strict == comparison in CGTEngine.processOutboundGroup with a tolerance of 0.00000001, matching the same approach already used in AssetEventValidator.     
           
Tests: Two new tests in CalculatorTests — one demonstrating the arithmetic noise directly, one verifying the engine completes the disposal correctly.   