### PR TITLE
Make tax-return total losses disposal-rounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Tax year    Gain    Proceeds   Exemption   Loss carry   Taxable gain
 1) SOLD 2000 of GB00B41YBW71 on 28/11/2019 for GAIN of £1140
 Matches with:
   - BED & BREAKFAST: 500 bought on 05/12/2019 at £4.7012
-  - SECTION 104: 2000 at cost basis of £3.89015
+  - SECTION 104: 1500 at cost basis of £3.89015
 Calculation: (2000 * 4.6702 - 12.5) - ( (500 * 4.7012 + 2) + (1500 * 3.89015) ) = 1140
 
 

--- a/Sources/CGTCalcCore/Formatter/TaxReturnMath.swift
+++ b/Sources/CGTCalcCore/Formatter/TaxReturnMath.swift
@@ -36,7 +36,7 @@ extension TaxYearSummary {
       .reduce(Decimal(0)) { $0 + TaxMethods.roundedGain($1.rawGain) }
     let totalLosses = self.disposals
       .filter { $0.rawGain < 0 }
-      .reduce(Decimal(0)) { $0 + TaxMethods.roundedGain(abs($1.rawGain)) }
+      .reduce(Decimal(0)) { $0 + abs(TaxMethods.roundedGain($1.rawGain)) }
 
     let specialRateSplit: TaxReturnMath.SpecialRateSplit?
     if let cutoff = self.taxYear.specialCapitalGainsRateChangeLastOldRateDate,

--- a/Tests/CGTCalcCoreTests/ModelCoverageTests.swift
+++ b/Tests/CGTCalcCoreTests/ModelCoverageTests.swift
@@ -183,7 +183,8 @@ final class ModelCoverageTests: XCTestCase {
     XCTAssertEqual(taxReturn.proceeds, 25)
     XCTAssertEqual(taxReturn.allowableCosts, 20)
     XCTAssertEqual(taxReturn.totalGains, 7)
-    XCTAssertEqual(taxReturn.totalLosses, 1)
+    // rawGain -1.25 floors to -£2 per disposal, so losses total £2.
+    XCTAssertEqual(taxReturn.totalLosses, 2)
 
     let split = try XCTUnwrap(taxReturn.specialRateSplit)
     XCTAssertEqual(split.label, "29th October")

--- a/Tests/CGTCalcCoreTests/TaxReturnMathTests.swift
+++ b/Tests/CGTCalcCoreTests/TaxReturnMathTests.swift
@@ -29,7 +29,8 @@ final class TaxReturnMathTests: XCTestCase {
     XCTAssertEqual(summary.taxReturnMath.proceeds, 2)
     XCTAssertEqual(summary.taxReturnMath.allowableCosts, 2)
     XCTAssertEqual(summary.taxReturnMath.totalGains, 0)
-    XCTAssertEqual(summary.taxReturnMath.totalLosses, 0)
+    // Two 99p losses each floor to -£1 per disposal, so losses total £2.
+    XCTAssertEqual(summary.taxReturnMath.totalLosses, 2)
   }
 
   func testTaxReturnUsesPerDisposalRoundedValuesForMixedPenceGainAndLoss() throws {
@@ -44,7 +45,8 @@ final class TaxReturnMathTests: XCTestCase {
     XCTAssertEqual(summary.taxReturnMath.proceeds, 1)
     XCTAssertEqual(summary.taxReturnMath.allowableCosts, 2)
     XCTAssertEqual(summary.taxReturnMath.totalGains, 0)
-    XCTAssertEqual(summary.taxReturnMath.totalLosses, 0)
+    // The 99p loss floors to -£1 per disposal (the 99p gain floors to £0), so losses total £1.
+    XCTAssertEqual(summary.taxReturnMath.totalLosses, 1)
   }
 
   func testTaxReturnUsesPerDisposalRoundedValuesForMixedSection104AndThirtyDayMatch() throws {

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/BuySellAllBuyAgainCapitalReturn.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/BuySellAllBuyAgainCapitalReturn.txt
@@ -32,7 +32,7 @@ Calculation: (40 * 197.12 - 12.5) - ( (40 * 196.95225) ) = -6
 # TAX RETURN INFORMATION
 
 2018/2019: Disposals = 1, proceeds = 19422, allowable costs = 18337, total gains = 1084, total losses = 0
-2019/2020: Disposals = 1, proceeds = 7884, allowable costs = 7890, total gains = 0, total losses = 5
+2019/2020: Disposals = 1, proceeds = 7884, allowable costs = 7890, total gains = 0, total losses = 6
 
 
 # HOLDINGS

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/MultipleMatches.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/MultipleMatches.txt
@@ -42,9 +42,9 @@ Calculation: (10 * 4.6702 - 12.5) - ( (10 * 5.4065) ) = -20
 
 # TAX RETURN INFORMATION
 
-2018/2019: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 19
-2019/2020: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 19
-2020/2021: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 19
+2018/2019: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 20
+2019/2020: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 20
+2020/2021: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 20
 
 
 # HOLDINGS

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SameDayMerge.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SameDayMerge.txt
@@ -20,7 +20,7 @@ Calculation: (20 * 8 - 14.5) - ( (20 * 8.21667) ) = -19
 
 # TAX RETURN INFORMATION
 
-2018/2019: Disposals = 1, proceeds = 160, allowable costs = 178, total gains = 0, total losses = 18
+2018/2019: Disposals = 1, proceeds = 160, allowable costs = 178, total gains = 0, total losses = 19
 
 
 # HOLDINGS

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SameDayMergeInterleaved.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SameDayMergeInterleaved.txt
@@ -20,7 +20,7 @@ Calculation: (20 * 8 - 14.5) - ( (20 * 8.21667) ) = -19
 
 # TAX RETURN INFORMATION
 
-2018/2019: Disposals = 1, proceeds = 160, allowable costs = 178, total gains = 0, total losses = 18
+2018/2019: Disposals = 1, proceeds = 160, allowable costs = 178, total gains = 0, total losses = 19
 
 
 # HOLDINGS

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/Simple.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/Simple.txt
@@ -20,7 +20,7 @@ Calculation: (10 * 4.6702 - 12.5) - ( (10 * 4.1565 + 12.5) ) = -20
 
 # TAX RETURN INFORMATION
 
-2018/2019: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 19
+2018/2019: Disposals = 1, proceeds = 46, allowable costs = 66, total gains = 0, total losses = 20
 
 
 # HOLDINGS

--- a/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SimpleTwoSameDay.txt
+++ b/Tests/CGTCalcCoreTests/TestData/Examples/Outputs/SimpleTwoSameDay.txt
@@ -25,7 +25,7 @@ Calculation: (10 * 4.6702 - 12.5) - ( (10 * 4.1565 + 12.5) ) = -20
 
 # TAX RETURN INFORMATION
 
-2018/2019: Disposals = 2, proceeds = 92, allowable costs = 132, total gains = 0, total losses = 38
+2018/2019: Disposals = 2, proceeds = 92, allowable costs = 132, total gains = 0, total losses = 40
 
 
 # HOLDINGS


### PR DESCRIPTION
Align the TAX RETURN INFORMATION `total losses` figure with the per-disposal LOSS lines, the same disposal-rounded basis that proceeds, allowable costs, and gains use after https://github.com/mattjgalloway/cgtcalc/issues/23.

On `main`, `total losses` rounds the loss magnitude while each disposal floors its signed raw gain, so the two disagree for any fractional loss. It shows up in the committed `BuySellAllBuyAgainCapitalReturn` fixture: the workings print `LOSS of £6` and `1 losses with total of 6`, but the tax-return box prints `total losses = 5`.

Raw loss −5.79 floors to −£6 per disposal, whereas `TaxReturnMath.totalLosses` computes `roundedGain(abs(−5.79)) = 5`. Since `roundedGain` floors, `round(|x|) != |round(x)|`; summing `abs(roundedGain(rawGain))` fixes it.

Draft on purpose since it's a genuine either/or. `TAX_DECISIONS.md` currently describes losses as "the sum of rounded positive per-disposal losses", which matches the current magnitude-rounding. If aligning with the per-disposal basis is what you want I'll finish it and update that wording; if the current behaviour is intended, happy to close.

Also folds in a one-line README fix: the worked example prints `SECTION 104: 2000`, but the calculation on the next line uses 1500 (500 B&B + 1500 Section 104 = 2000 sold).
